### PR TITLE
file_sender.py: Fix encryption for file and folder

### DIFF
--- a/Desktop-app/file_sender.py
+++ b/Desktop-app/file_sender.py
@@ -56,6 +56,9 @@ class FileSender(QThread):
         if not self.initialize_connection():
             return
 
+        self.encryption_flag = self.config['encryption']
+        # logger.debug("Encryption flag: %s", self.encryption_flag)
+
         for file_path in self.file_paths:
             if os.path.isdir(file_path):
                 self.send_folder(file_path)
@@ -63,7 +66,7 @@ class FileSender(QThread):
                 if not self.metadata_created:
                     metadata_file_path = self.create_metadata(file_paths=self.file_paths)
                     self.send_file(metadata_file_path)
-                self.send_file(file_path)
+                self.send_file(file_path, encrypted_transfer=self.encryption_flag)
         
         # Delete metadata file
         if self.metadata_created and metadata_file_path:
@@ -132,7 +135,9 @@ class FileSender(QThread):
             file_path = os.path.join(folder_path, relative_file_path)
             if not relative_file_path.endswith('.delete'):
                 if file_info['size'] > 0:
-                    self.send_file(file_path, relative_file_path=relative_file_path)
+                    if self.encryption_flag:
+                        relative_file_path += ".crypt"
+                    self.send_file(file_path, relative_file_path=relative_file_path, encrypted_transfer=self.encryption_flag)
                 else:
                     # Handle directory creation (if needed, in receiver)
                     pass
@@ -140,11 +145,17 @@ class FileSender(QThread):
         # Clean up metadata file
         os.remove(metadata_file_path)
 
-
-    def send_file(self, file_path, relative_file_path=None):
+    def send_file(self, file_path, relative_file_path=None, encrypted_transfer=False):
         logger.debug("Sending file: %s", file_path)
         # if self.metadata_created:
         #     self.createmetadata(file_path=file_path)
+
+        # Encrypt the file if encrypted_transfer argument is present
+        if encrypted_transfer:
+            logger.debug("Encrypted transfer with password: %s", self.password)
+
+            file_path = encrypt_file(file_path, self.password)
+
         sent_size = 0
         file_size = os.path.getsize(file_path)
         if relative_file_path is None:
@@ -152,7 +163,8 @@ class FileSender(QThread):
         file_name_size = len(relative_file_path.encode())
         logger.debug("Sending %s, %s", relative_file_path, file_size)
 
-        encryption_flag = 'encyp: t' if self.config['encryption'] else 'encyp: f'
+        encryption_flag = 'encyp: t' if encrypted_transfer else 'encyp: f'
+
         self.client_skt.send(encryption_flag.encode())
         logger.debug("Sent encryption flag: %s", encryption_flag)
 
@@ -168,7 +180,7 @@ class FileSender(QThread):
                 sent_size += len(data)
                 self.progress_update.emit(sent_size * 100 // file_size)
 
-        if self.config['encryption']:
+        if encrypted_transfer:
             os.remove(file_path)
 
         return True


### PR DESCRIPTION
for folder, metadata is sent without encryption_flag so that receiver doesn't have to decrypt it during the transfer. For folders, files except metadata.json are encrypted and decrypted at their respective paths