### PR TITLE
file_sender.py: Fix encryption for file and folder

### DIFF
--- a/Desktop-app/file_sender.py
+++ b/Desktop-app/file_sender.py
@@ -223,6 +223,8 @@ class SendApp(QWidget):
         self.initUI()
 
     def initUI(self):
+        self.config = get_config()
+        logger.debug("Encryption : %s", self.config['encryption'])
         self.setWindowTitle('Send File')
         self.setGeometry(100, 100, 400, 300)
         self.center_window()


### PR DESCRIPTION
for folder, metadata is sent without encryption_flag so that receiver doesn't have to decrypt it during the transfer. For folders, files except metadata.json are encrypted and decrypted at their respective paths